### PR TITLE
Introduce `NimbusApi` and deprecate `AuthorFilterAPI`

### DIFF
--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -185,7 +185,7 @@ where
 		// those keys until we find one that is eligible. If none are eligible, we skip this slot.
 		// If multiple are eligible, we only author with the first one.
 
-		// Get allthe available keys
+		// Get all the available keys
 		let available_keys =
 			SyncCryptoStore::keys(&*self.keystore, NIMBUS_KEY_ID)
 			.expect("keystore should return the keys it has");
@@ -208,9 +208,7 @@ where
 				.expect("should be able to dynamically detect the api");
 			
 			if has_nimbus_api {
-				// I understand that this is ambiguous, but I don't understand how to disambiguate.
-				// The compiler's suggestion does not work. See where I called the author filter api below.
-				self.parachain_client.runtime_api().can_author(at, nimbus_id, slot, parent)
+				NimbusApi::can_author(&*self.parachain_client.runtime_api(), at, nimbus_id, slot, parent)
 					.expect("NimbusAPI should not return error")
 			} else {
 				// There are two versions of the author filter, so we do that dynamically also.
@@ -220,7 +218,7 @@ where
 					.expect("Should be able to detect author filter version");
 
 				if api_version >= 2 {
-					AuthorFilterAPI::can_author(&self.parachain_client.runtime_api(), at, nimbus_id, slot, parent)
+					AuthorFilterAPI::can_author(&*self.parachain_client.runtime_api(), at, nimbus_id, slot, parent)
 						.expect("Author API should not return error")
 				} else {
 					#[allow(deprecated)]

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -170,7 +170,7 @@ where
 		Proof = <EnableProofRecording as ProofRecording>::Proof,
 	>,
 	ParaClient: ProvideRuntimeApi<B> + Send + Sync,
-	ParaClient::Api: NimbusApi<B, NimbusId>,
+	ParaClient::Api: NimbusApi<B>,
 	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData, NimbusId)>,
 {
 	async fn produce_candidate(
@@ -197,7 +197,7 @@ where
 		let at = BlockId::Hash(parent.hash());
 		// Get `NimbusApi` version.
 		let api_version = self.parachain_client.runtime_api()
-			.api_version::<dyn NimbusApi<B, NimbusId>>(&at)
+			.api_version::<dyn NimbusApi<B>>(&at)
 			.expect("Runtime api access to not error.");
 
 		if api_version.is_none() {
@@ -393,7 +393,7 @@ where
 	// Rust bug: https://github.com/rust-lang/rust/issues/24159
 	sc_client_api::StateBackendFor<RBackend, PBlock>: sc_client_api::StateBackend<HashFor<PBlock>>,
 	ParaClient: ProvideRuntimeApi<Block> + Send + Sync + 'static,
-	ParaClient::Api: NimbusApi<Block, NimbusId>,
+	ParaClient::Api: NimbusApi<Block>,
 	CIDP: CreateInherentDataProviders<Block, (PHash, PersistedValidationData, NimbusId)> + 'static,
 {
 	NimbusConsensusBuilder::new(
@@ -475,7 +475,7 @@ where
 	/// Build the nimbus consensus.
 	fn build(self) -> Box<dyn ParachainConsensus<Block>>
 	where
-		ParaClient::Api: NimbusApi<Block, NimbusId>,
+		ParaClient::Api: NimbusApi<Block>,
 	{
 		self.relay_chain_client.clone().execute_with(self)
 	}
@@ -497,7 +497,7 @@ where
 	BI: BlockImport<Block> + Send + Sync + 'static,
 	RBackend: Backend<PBlock> + 'static,
 	ParaClient: ProvideRuntimeApi<Block> + Send + Sync + 'static,
-	ParaClient::Api: NimbusApi<Block, NimbusId>,
+	ParaClient::Api: NimbusApi<Block>,
 	CIDP: CreateInherentDataProviders<Block, (PHash, PersistedValidationData, NimbusId)> + 'static,
 {
 	type Output = Box<dyn ParachainConsensus<Block>>;
@@ -509,7 +509,7 @@ where
 		PBackend::State: sp_api::StateBackend<sp_runtime::traits::BlakeTwo256>,
 		Api: polkadot_client::RuntimeApiCollection<StateBackend = PBackend::State>,
 		PClient: polkadot_client::AbstractClient<PBlock, PBackend, Api = Api> + 'static,
-		ParaClient::Api: NimbusApi<Block, NimbusId>,
+		ParaClient::Api: NimbusApi<Block>,
 	{
 		Box::new(NimbusConsensus::new(
 			self.para_id,

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -136,11 +136,23 @@ sp_application_crypto::with_pair! {
 
 sp_api::decl_runtime_apis! {
 	/// The runtime api used to predict whether a Nimbus author will be eligible in the given slot
-	#[api_version(2)]
 	pub trait NimbusApi {
-		#[changed_in(2)]
-		fn can_author(author: NimbusId, relay_parent: u32) -> bool;
-
 		fn can_author(author: NimbusId, relay_parent: u32, parent_header: &Block::Header) -> bool;
+	}
+
+
+	// #[deprecated]
+	// The macro ended up always making the warning print
+	// so I decided to bail on that.
+	
+	/// Deprecated Runtime API from earlier versions of Nimbus.
+	/// It is retained for now so that live chains can temporarily support both
+	/// for a smooth migration. It will be removed soon.
+	#[api_version(2)]
+	pub trait AuthorFilterAPI<AuthorId: parity_scale_codec::Codec> {
+		#[changed_in(2)]
+		fn can_author(author: AuthorId, relay_parent: u32) -> bool;
+
+		fn can_author(author: AuthorId, relay_parent: u32, parent_header: &Block::Header) -> bool;
 	}
 }

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -22,7 +22,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_std::vec::Vec;
-use parity_scale_codec::Codec;
 use sp_application_crypto::KeyTypeId;
 use sp_runtime::ConsensusEngineId;
 use sp_runtime::traits::BlockNumberProvider;
@@ -95,13 +94,13 @@ impl<T> CanAuthor<T> for () {
 /// different notions of AccoutId. It is also generic over the AuthorId to
 /// support the usecase where the author inherent is used for beneficiary info
 /// and contains an AccountId directly.
-pub trait AccountLookup<AuthorId, AccountId> {
-	fn lookup_account(author: &AuthorId) -> Option<AccountId>;
+pub trait AccountLookup<AccountId> {
+	fn lookup_account(author: &NimbusId) -> Option<AccountId>;
 }
 
 // A dummy impl used in simple tests
-impl<AuthorId, AccountId> AccountLookup<AuthorId, AccountId> for () {
-	fn lookup_account(_: &AuthorId) -> Option<AccountId> {
+impl<AccountId> AccountLookup<AccountId> for () {
+	fn lookup_account(_: &NimbusId) -> Option<AccountId> {
 		None
 	}
 }
@@ -138,10 +137,10 @@ sp_application_crypto::with_pair! {
 sp_api::decl_runtime_apis! {
 	/// The runtime api used to predict whether a Nimbus author will be eligible in the given slot
 	#[api_version(2)]
-	pub trait NimbusApi<AuthorId: Codec> {
+	pub trait NimbusApi {
 		#[changed_in(2)]
-		fn can_author(author: AuthorId, relay_parent: u32) -> bool;
+		fn can_author(author: NimbusId, relay_parent: u32) -> bool;
 
-		fn can_author(author: AuthorId, relay_parent: u32, parent_header: &Block::Header) -> bool;
+		fn can_author(author: NimbusId, relay_parent: u32, parent_header: &Block::Header) -> bool;
 	}
 }

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -67,14 +67,10 @@ pub mod pallet {
 		type SlotBeacon: SlotBeacon;
 	}
 
-	// If the AccountId type supports it, then this pallet can be BoundToRuntimeAppPublic
-	impl<T> sp_runtime::BoundToRuntimeAppPublic for Pallet<T>
-	// where
-	// 	T: Config,
-	// 	T::AuthorId: RuntimeAppPublic,
-	{
+	impl<T> sp_runtime::BoundToRuntimeAppPublic for Pallet<T> {
 		type Public = NimbusId;
 	}
+
 	#[pallet::error]
 	pub enum Error<T> {
 		/// Author already set in block.

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -174,7 +174,7 @@ pub mod pallet {
 	}
 
 	/// To learn whether a given NimbusId can author, as opposed to an account id, you
-	/// can ask this pallet idrectly. It will do the mapping for you.
+	/// can ask this pallet directly. It will do the mapping for you.
 	impl<T: Config> CanAuthor<NimbusId> for Pallet<T> {
 		fn can_author(author: &NimbusId, slot: &u32) -> bool {
 			let account = match T::AccountLookup::lookup_account(&author) {

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -703,6 +703,15 @@ impl_runtime_apis! {
 		}
 	}
 
+	// We also implement the olf AuthorFilterAPI to support nodes that have not yet updated the client side.
+	impl nimbus_primitives::AuthorFilterAPI<Block, NimbusId> for Runtime {
+		fn can_author(author: NimbusId, slot: u32, parent_header: &<Block as BlockT>::Header) -> bool {
+			System::initialize(&(parent_header.number + 1), &parent_header.hash(), &parent_header.digest, frame_system::InitKind::Inspection);
+			<Self as pallet_author_slot_filter::Config>::RandomnessSource::on_initialize(System::block_number());
+			<AuthorInherent as nimbus_primitives::CanAuthor<_>>::can_author(&author, &slot)
+		}
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn benchmark_metadata(extra: bool) -> (

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -703,15 +703,6 @@ impl_runtime_apis! {
 		}
 	}
 
-	// We also implement the olf AuthorFilterAPI to support nodes that have not yet updated the client side.
-	impl nimbus_primitives::AuthorFilterAPI<Block, NimbusId> for Runtime {
-		fn can_author(author: NimbusId, slot: u32, parent_header: &<Block as BlockT>::Header) -> bool {
-			System::initialize(&(parent_header.number + 1), &parent_header.hash(), &parent_header.digest, frame_system::InitKind::Inspection);
-			<Self as pallet_author_slot_filter::Config>::RandomnessSource::on_initialize(System::block_number());
-			<AuthorInherent as nimbus_primitives::CanAuthor<_>>::can_author(&author, &slot)
-		}
-	}
-
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn benchmark_metadata(extra: bool) -> (

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -550,9 +550,7 @@ impl pallet_author_slot_filter::Config for Runtime {
 	type PotentialAuthors = PotentialAuthorSet;
 }
 
-impl pallet_account_set::Config for Runtime {
-	type AuthorId = NimbusId;
-}
+impl pallet_account_set::Config for Runtime {}
 
 /// Configure the pallet template in pallets/template.
 impl pallet_template::Config for Runtime {

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -703,12 +703,10 @@ impl_runtime_apis! {
 		}
 	}
 
-	// We also implement the olf AuthorFilterAPI to support nodes that have not yet updated the client side.
+	// We also implement the olf AuthorFilterAPI to meet the trait bounds on the client side.
 	impl nimbus_primitives::AuthorFilterAPI<Block, NimbusId> for Runtime {
-		fn can_author(author: NimbusId, slot: u32, parent_header: &<Block as BlockT>::Header) -> bool {
-			System::initialize(&(parent_header.number + 1), &parent_header.hash(), &parent_header.digest, frame_system::InitKind::Inspection);
-			<Self as pallet_author_slot_filter::Config>::RandomnessSource::on_initialize(System::block_number());
-			<AuthorInherent as nimbus_primitives::CanAuthor<_>>::can_author(&author, &slot)
+		fn can_author(_: NimbusId, _: u32, _: &<Block as BlockT>::Header) -> bool {
+			panic!("AuthorFilterAPI is no longer supported. Please update your client.")
 		}
 	}
 

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -537,7 +537,6 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 }
 
 impl pallet_author_inherent::Config for Runtime {
-	type AuthorId = NimbusId;
 	// We start a new slot each time we see a new relay block.
 	type SlotBeacon = cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;
 	type AccountLookup = PotentialAuthorSet;
@@ -693,8 +692,8 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl nimbus_primitives::NimbusApi<Block, nimbus_primitives::NimbusId> for Runtime {
-		fn can_author(author: nimbus_primitives::NimbusId, slot: u32, parent_header: &<Block as BlockT>::Header) -> bool {
+	impl nimbus_primitives::NimbusApi<Block> for Runtime {
+		fn can_author(author: NimbusId, slot: u32, parent_header: &<Block as BlockT>::Header) -> bool {
 			// This runtime uses an entropy source that is updated during block initialization
 			// Therefore we need to initialize it to match the state it will be in when the
 			// next block is being executed.

--- a/parachain-template/runtime/src/pallet_account_set.rs
+++ b/parachain-template/runtime/src/pallet_account_set.rs
@@ -36,7 +36,7 @@ pub mod pallet {
 	use log::warn;
 	use frame_support::pallet_prelude::*;
 	use sp_std::vec::Vec;
-	use nimbus_primitives::{AccountLookup, CanAuthor};
+	use nimbus_primitives::{AccountLookup, CanAuthor, NimbusId};
 
 	/// The Account Set pallet
 	#[pallet::pallet]
@@ -44,10 +44,7 @@ pub mod pallet {
 
 	/// Configuration trait of this pallet.
 	#[pallet::config]
-	pub trait Config: frame_system::Config  {
-		/// The identifier type for an author.
-		type AuthorId: Member + Parameter + MaybeSerializeDeserialize;
-	}
+	pub trait Config: frame_system::Config  {}
 
 	/// The set of accounts that is stored in this pallet.
 	#[pallet::storage]
@@ -63,13 +60,13 @@ pub mod pallet {
 	#[pallet::getter(fn account_id_of)]
 	/// A mapping from the AuthorIds used in the consensus layer
 	/// to the AccountIds runtime.
-	type Mapping<T: Config> = StorageMap<_, Twox64Concat, T::AuthorId, T::AccountId, OptionQuery>;
+	type Mapping<T: Config> = StorageMap<_, Twox64Concat, NimbusId, T::AccountId, OptionQuery>;
 
 	#[pallet::genesis_config]
 	/// Genesis config for author mapping pallet
 	pub struct GenesisConfig<T: Config> {
 		/// The associations that should exist at chain genesis
-		pub mapping: Vec<(T::AccountId, T::AuthorId)>,
+		pub mapping: Vec<(T::AccountId, NimbusId)>,
 	}
 
 	#[cfg(feature = "std")]
@@ -100,8 +97,8 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> AccountLookup<T::AuthorId, T::AccountId> for Pallet<T> {
-		fn lookup_account(author: &T::AuthorId) -> Option<T::AccountId> {
+	impl<T: Config> AccountLookup<T::AccountId> for Pallet<T> {
+		fn lookup_account(author: &NimbusId) -> Option<T::AccountId> {
 			Mapping::<T>::get(&author)
 		}
 	}


### PR DESCRIPTION
The PR gives the runtime API a makeover in terms of a new name, and no more generic `AuthorId` type. As a consequence, we are able to remove the generic type parameter, `AuthorId`, from the entire nimbus stack.

This PR maintains support for the old `AuthorFilterApi` on the client side to give live chains time to transition. However, the runtime removes support for the old api, and simply panics when it is called. This just means that the runtime upgrade must happen after the majority of client nodes have upgraded.

### Historical Context

When slot prediction was first introduced it was used in two ways:
* For signed blocks using `AuthorId = NimbusId`, as it is now
* For unsigned blocks using `AuthorId = Runtime::AccountId`

Now that block signing is used everywhere, as it should be, the ability to use it for unsigned blocks is no longer necessary. Removing it makes installing nimbus easier and less confusing.

### Migration

This PR makes breaking changes to a runtime api. It is recommended that they be introduced into existing chains like so:

* Starting with a client and runtime that only support the old `AuthorFilterApi`
* Client release that dynamically starts using the `NimbusApi` when the runtime supports is (nimbus v0.9)
* Runtime upgrade that adds support for the `NimbusApi` (nimbus v0.9)
* Eventually, remove support for `AuthorFilterApi` entirely (nimbus v0.10)