### PR TITLE
Stop providing author inherent data

### DIFF
--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -91,7 +91,7 @@ where
 	RClient::Api: ParachainHost<PBlock>,
 	RBackend: Backend<PBlock>,
 	ParaClient: ProvideRuntimeApi<B>,
-	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData, NimbusId)>,
+	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData)>,
 {
 	/// Create a new instance of nimbus consensus.
 	pub fn new(
@@ -121,18 +121,15 @@ where
 		}
 	}
 
-	//TODO Could this be a provided implementation now that we have this async inherent stuff?
-	/// Create the data.
 	async fn inherent_data(
 		&self,
 		parent: B::Hash,
 		validation_data: &PersistedValidationData,
 		relay_parent: PHash,
-		author_id: NimbusId,
 	) -> Option<InherentData> {
 		let inherent_data_providers = self
 			.create_inherent_data_providers
-			.create_inherent_data_providers(parent, (relay_parent, validation_data.clone(), author_id))
+			.create_inherent_data_providers(parent, (relay_parent, validation_data.clone()))
 			.await
 			.map_err(|e| {
 				tracing::error!(
@@ -303,7 +300,7 @@ where
 	// We require the client to provide both runtime apis, but only one will be called
 	ParaClient::Api: AuthorFilterAPI<B, NimbusId>,
 	ParaClient::Api: NimbusApi<B>,
-	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData, NimbusId)>,
+	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData)>,
 {
 	async fn produce_candidate(
 		&mut self,
@@ -334,7 +331,7 @@ where
 			)
 			.ok()?;
 
-		let inherent_data = self.inherent_data(parent.hash(),&validation_data, relay_parent, NimbusId::from_slice(&type_public_pair.1)).await?;
+		let inherent_data = self.inherent_data(parent.hash(),&validation_data, relay_parent).await?;
 
 		let inherent_digests = sp_runtime::generic::Digest {
 			logs: vec![
@@ -457,7 +454,7 @@ where
 	ParaClient: ProvideRuntimeApi<Block> + Send + Sync + 'static,
 	ParaClient::Api: NimbusApi<Block>,
 	ParaClient::Api: AuthorFilterAPI<Block, NimbusId>,
-	CIDP: CreateInherentDataProviders<Block, (PHash, PersistedValidationData, NimbusId)> + 'static,
+	CIDP: CreateInherentDataProviders<Block, (PHash, PersistedValidationData)> + 'static,
 {
 	NimbusConsensusBuilder::new(
 		para_id,
@@ -507,7 +504,7 @@ where
 	BI: BlockImport<Block> + Send + Sync + 'static,
 	RBackend: Backend<PBlock> + 'static,
 	ParaClient: ProvideRuntimeApi<Block> + Send + Sync + 'static,
-	CIDP: CreateInherentDataProviders<Block, (PHash, PersistedValidationData, NimbusId)> + 'static,
+	CIDP: CreateInherentDataProviders<Block, (PHash, PersistedValidationData)> + 'static,
 {
 	/// Create a new instance of the builder.
 	fn new(
@@ -563,7 +560,7 @@ where
 	ParaClient: ProvideRuntimeApi<Block> + Send + Sync + 'static,
 	ParaClient::Api: NimbusApi<Block>,
 	ParaClient::Api: AuthorFilterAPI<Block, NimbusId>,
-	CIDP: CreateInherentDataProviders<Block, (PHash, PersistedValidationData, NimbusId)> + 'static,
+	CIDP: CreateInherentDataProviders<Block, (PHash, PersistedValidationData)> + 'static,
 {
 	type Output = Box<dyn ParachainConsensus<Block>>;
 

--- a/nimbus-primitives/src/inherents.rs
+++ b/nimbus-primitives/src/inherents.rs
@@ -15,24 +15,23 @@
 // along with Nimbus.  If not, see <http://www.gnu.org/licenses/>.
 
 use sp_inherents::{InherentData, InherentIdentifier};
-use parity_scale_codec::Encode;
 
 /// The InherentIdentifier for nimbus's author inherent
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"author__";
 
-/// A thing that an outer node could use to inject the inherent data.
-/// This should be used in simple uses of the author inherent (eg permissionless authoring)
-/// When using the full nimbus system, we are manually inserting the inherent.
-pub struct InherentDataProvider<AuthorId>(pub AuthorId);
+/// A bare minimum inherent data provider that provides no real data.
+/// The inherent is simply used as a way to kick off some computation
+/// until https://github.com/paritytech/substrate/pull/10128 lands.
+pub struct InherentDataProvider;
 
 #[cfg(feature = "std")]
 #[async_trait::async_trait]
-impl<AuthorId: Encode + Send + Sync> sp_inherents::InherentDataProvider for InherentDataProvider<AuthorId> {
+impl sp_inherents::InherentDataProvider for InherentDataProvider {
 	fn provide_inherent_data(
 		&self,
 		inherent_data: &mut InherentData,
 	) -> Result<(), sp_inherents::Error> {
-		inherent_data.put_data(INHERENT_IDENTIFIER, &self.0)
+		inherent_data.put_data(INHERENT_IDENTIFIER, &())
 	}
 
 	async fn try_handle_error(
@@ -46,6 +45,6 @@ impl<AuthorId: Encode + Send + Sync> sp_inherents::InherentDataProvider for Inhe
 		}
 
 		// All errors with the author inehrent are fatal
-		Some(Err(sp_inherents::Error::Application(Box::from(String::from("Error processing author inherent")))))
+		Some(Err(sp_inherents::Error::Application(Box::from(String::from("Error processing dummy nimbus inherent")))))
 	}
 }

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -395,9 +395,9 @@ pub async fn start_parachain_node(
 							)
 						})?;
 
-						let author = nimbus_primitives::InherentDataProvider;
+let nimbus_inherent = nimbus_primitives::InherentDataProvider;
 
-						Ok((time, parachain_inherent, author))
+						Ok((time, parachain_inherent, nimbus_inherent))
 					}
 				},
 			}))

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -395,7 +395,7 @@ pub async fn start_parachain_node(
 							)
 						})?;
 
-let nimbus_inherent = nimbus_primitives::InherentDataProvider;
+						let nimbus_inherent = nimbus_primitives::InherentDataProvider;
 
 						Ok((time, parachain_inherent, nimbus_inherent))
 					}

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 // Local Runtime Types
 use parachain_template_runtime::{
-	opaque::Block, AccountId, Balance, Hash, Index as Nonce, RuntimeApi, NimbusId
+	opaque::Block, AccountId, Balance, Hash, Index as Nonce, RuntimeApi
 };
 
 use nimbus_consensus::{
@@ -381,7 +381,7 @@ pub async fn start_parachain_node(
 						keystore,
 						skip_prediction: force_authoring,
 						create_inherent_data_providers:
-							move |_, (relay_parent, validation_data, author_id)| {
+							move |_, (relay_parent, validation_data)| {
 								let parachain_inherent =
 								cumulus_primitives_parachain_inherent::ParachainInherentData::create_at_with_client(
 									relay_parent,
@@ -399,7 +399,7 @@ pub async fn start_parachain_node(
 										)
 									})?;
 
-									let author = nimbus_primitives::InherentDataProvider::<NimbusId>(author_id);
+									let author = nimbus_primitives::InherentDataProvider;
 
 									Ok((time, parachain_inherent, author))
 								}

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 // Local Runtime Types
 use parachain_template_runtime::{
-	opaque::Block, AccountId, Balance, Hash, Index as Nonce, NimbusId, RuntimeApi,
+	opaque::Block, AccountId, Balance, Hash, Index as Nonce, RuntimeApi,
 };
 
 use nimbus_consensus::{


### PR DESCRIPTION
DO NOT MERGE until after nimbus 0.9 has been tagged.

This PR is a followup to #15. It simplifies the client-side code by no longer providing any real inherent data. Previously it provided the author id, but since #15, the data supplied there has not been used, and the pre-runtime digest is used instead.