### PR TITLE
Prepare for 0.9 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4246,7 +4246,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-consensus"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-primitives"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura-style-filter"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-author-inherent"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-author-slot-filter"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-template-node"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-template-runtime"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",

--- a/nimbus-consensus/Cargo.toml
+++ b/nimbus-consensus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nimbus-consensus"
-description = "Client-side worker for the Nimbus family of slot-based consensus algorithms"
-version = "0.1.0"
+description = "Client-side worker for the Nimbus family of consensus algorithms"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/nimbus-primitives/Cargo.toml
+++ b/nimbus-primitives/Cargo.toml
@@ -2,8 +2,8 @@
 authors = ["PureStake"]
 edition = "2021"
 name = "nimbus-primitives"
-version = "0.1.0"
-description = "Primitive types and traites used in the nimbus consensus framework"
+version = "0.9.0"
+description = "Primitive types and traits used in the Nimbus consensus framework"
 
 [dependencies]
 parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }

--- a/pallets/aura-style-filter/Cargo.toml
+++ b/pallets/aura-style-filter/Cargo.toml
@@ -2,7 +2,8 @@
 authors = ["PureStake"]
 edition = "2021"
 name = "pallet-aura-style-filter"
-version = "0.1.0"
+description = "The Aura (authority round) consensus engine implemented in the Nimbus framework"
+version = "0.9.0"
 
 [dependencies]
 parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }

--- a/pallets/author-inherent/Cargo.toml
+++ b/pallets/author-inherent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pallet-author-inherent"
-version = "0.1.0"
-description = "Inject the block author via an inherent, and persist it via a Consensus digest"
+version = "0.9.0"
+description = "This pallet is the core of the in-runtime portion of Nimbus."
 authors = ["PureStake"]
 edition = "2021"
 license = 'GPL-3.0-only'

--- a/pallets/author-slot-filter/Cargo.toml
+++ b/pallets/author-slot-filter/Cargo.toml
@@ -2,7 +2,8 @@
 authors = ["PureStake"]
 edition = "2021"
 name = "pallet-author-slot-filter"
-version = "0.1.0"
+description = "Selects a pseudorandom Subset of eligible (probably staked) authors at each slot"
+version = "0.9.0"
 
 [dependencies]
 log = { version = "0.4", default-features = false }

--- a/parachain-template/node/Cargo.toml
+++ b/parachain-template/node/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "parachain-template-node"
-version = "0.1.0"
+version = "0.9.0"
 authors = ["Anonymous"]
-description = "A new Cumulus FRAME-based Substrate Node, ready for hacking together a parachain."
+description = "A Substrate node that demonstrates using the Nimbus consensus framework with instant seal and as a parachain."
 license = "Unlicense"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/cumulus/"

--- a/parachain-template/runtime/Cargo.toml
+++ b/parachain-template/runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "parachain-template-runtime"
-version = "0.1.0"
+version = "0.9.0"
 authors = ["Anonymous"]
-description = "A new Cumulus FRAME-based Substrate Runtime, ready for hacking together a parachain."
+description = "A FRAME-based Substrate Runtime, that demonstrates the Nimbus consensus framework."
 license = "Unlicense"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/cumulus/"


### PR DESCRIPTION
The 0.9 release contains primarily:

* Preruntime digest with backward compatibility
* NimbusApi with backward compatibility
* Newer Substrate ecosystem dependencies
* CI and cargo fmt in the repo (still a ways to go QA wise)