### PR TITLE
Fix author selection modulo bias issue

### DIFF
--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -82,14 +82,17 @@ pub mod pallet {
 			debug!(target: "author-filter", "🎲Randomness sample {}: {:?}", i, &randomness);
 
 			// Cast to u32 first so we get consistent results on 32- and 64-bit platforms.
-			let index = (randomness.to_fixed_bytes()[0] as u32) as usize;
+			let bytes: [u8; 4] = randomness.to_fixed_bytes()[0..4]
+				.try_into()
+				.expect("H256 has at least 4 bytes; qed");
+			let randomness = u32::from_le_bytes(bytes) as usize;
 
 			// Move the selected author from the original vector into the eligible vector
 			// TODO we could short-circuit this check by returning early when the claimed
 			// author is selected. For now I'll leave it like this because:
 			// 1. it is easier to understand what our core filtering logic is
 			// 2. we currently show the entire filtered set in the debug event
-			eligible.push(active.remove(index % active.len()));
+			eligible.push(active.remove(randomness % active.len()));
 		}
 		(eligible, active)
 	}


### PR DESCRIPTION
This fixes a fairness issue with the author selection that occurs when the number of selected candidates is not an even multiple of the candidate pool. This arises because we reduce our large randomness to a single byte and then modulo that by the desired number of selected candidates, resulting in some candidates having a higher probability than others.

Consider the following example:

```rust
let randomness = rand() % 16; // our randomness is 0-15
let num_selected = 14;

// here the candidates with index 0 or 1 have twice the chance of winning
// as everyone else. note that we reduce the significance of the bias but not
// remove it altogether by increasing the range of `randomness`.
let winner = randomness % num_selected;
```