### PR TITLE
Ensure slot number is strictly increasing

### DIFF
--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -122,7 +122,7 @@ pub mod pallet {
 			ensure_none(origin)?;
 
 			// First check that the slot number is valid (greater than the previous highest)
-			let slot= T::SlotBeacon::slot();
+			let slot = T::SlotBeacon::slot();
 			assert!(
 				slot > HighestSlotSeen::<T>::get(),
 				"Block invalid; Supplied slot number is not high enough"

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -128,16 +128,16 @@ pub mod pallet {
 				"Block invalid; Supplied slot number is not high enough"
 			);
 
-			HighestSlotSeen::<T>::put(slot);
-
 			// Now check that the author is valid in this slot
 			let author = <Author<T>>::get()
 				.expect("Block invalid, no authorship information supplied in preruntime digest.");
-
 			assert!(
 				T::CanAuthor::can_author(&author, &T::SlotBeacon::slot()),
 				"Block invalid, supplied author is not eligible."
 			);
+
+			// Once that is validated, update the stored slot number
+			HighestSlotSeen::<T>::put(slot);
 
 			Ok(Pays::No.into())
 		}

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -83,6 +83,11 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type Author<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
+	/// The highest slot that has been seen in the history of this chain.
+	/// This is a strictly-increasing value.
+	#[pallet::storage]
+	pub type HighestSlotSeen<T: Config> = StorageValue<_, u32, ValueQuery>;
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(_: T::BlockNumber) -> Weight {
@@ -116,6 +121,16 @@ pub mod pallet {
 		pub fn kick_off_authorship_validation(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
 
+			// First check that the slot number is valid (greater than the previous highest)
+			let slot= T::SlotBeacon::slot();
+			assert!(
+				slot > HighestSlotSeen::<T>::get(),
+				"Block invalid; Supplied slot number is not high enough"
+			);
+
+			HighestSlotSeen::<T>::put(slot);
+
+			// Now check that the author is valid in this slot
 			let author = <Author<T>>::get()
 				.expect("Block invalid, no authorship information supplied in preruntime digest.");
 


### PR DESCRIPTION
This PR adds a simple storage item and validation check that ensures the slot number associated with each block is always strictly greater than the previous highest slot number in this chain.

Nimbus has always assumed this invariant to be true, but has not enforced it. In the parachain context, we are guaranteed increasing slot numbers because we use the relay chain parent number which is always strictly increasing. But in other contexts, nimbus will need to ensure this manually. (Plus nimbus should ensure it manually anyways in case the design of cumulus ever changes without warning.)

This works toward #1 and #3