### PR TITLE
[MOON-1460] fix migration for author-slot-filter

### DIFF
--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -23,12 +23,7 @@
 use cumulus_client_consensus_common::{
 	ParachainBlockImport, ParachainCandidate, ParachainConsensus,
 };
-use cumulus_primitives_core::{
-	relay_chain::{
-		v1::{Hash as PHash},
-	},
-	ParaId, PersistedValidationData,
-};
+use cumulus_primitives_core::{relay_chain::v1::Hash as PHash, ParaId, PersistedValidationData};
 pub use import_queue::import_queue;
 use log::{debug, info, warn};
 use nimbus_primitives::{

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -218,4 +218,3 @@ impl InherentError {
 		}
 	}
 }
-

--- a/pallets/author-slot-filter/Cargo.toml
+++ b/pallets/author-slot-filter/Cargo.toml
@@ -44,3 +44,5 @@ std = [
 runtime-benchmarks = [
 	"frame-benchmarking",
 ]
+
+try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -158,6 +158,13 @@ pub mod pallet {
 	/// The type of eligibility to use
 	pub type EligibilityValue = NonZeroU32;
 
+	impl EligibilityValue {
+		/// Default total number of eligible authors, must NOT be 0.
+		pub fn default() -> Self {
+			NonZeroU32::new_unchecked(50)
+		}
+	}
+
 	#[pallet::storage]
 	#[pallet::getter(fn eligible_ratio)]
 	#[deprecated]
@@ -175,13 +182,10 @@ pub mod pallet {
 	pub type EligibleCount<T: Config> =
 		StorageValue<_, EligibilityValue, ValueQuery, DefaultEligibilityValue<T>>;
 
-	/// Default total number of eligible authors, must NOT be 0.
-	pub const DEFAULT_TOTAL_ELIGIBLE_AUTHORS: EligibilityValue = NonZeroU32::new_unchecked(50);
-
 	// Default value for the `EligibleCount`.
 	#[pallet::type_value]
 	pub fn DefaultEligibilityValue<T: Config>() -> EligibilityValue {
-		DEFAULT_TOTAL_ELIGIBLE_AUTHORS
+		EligibilityValue::default()
 	}
 
 	#[pallet::genesis_config]
@@ -193,7 +197,7 @@ pub mod pallet {
 	impl Default for GenesisConfig {
 		fn default() -> Self {
 			Self {
-				eligible_count: DEFAULT_TOTAL_ELIGIBLE_AUTHORS,
+				eligible_count: EligibilityValue::default(),
 			}
 		}
 	}

--- a/pallets/author-slot-filter/src/migration.rs
+++ b/pallets/author-slot-filter/src/migration.rs
@@ -26,6 +26,7 @@ use frame_support::traits::OnRuntimeUpgradeHelpersExt;
 
 use super::num::NonZeroU32;
 use super::pallet::Config;
+use super::pallet::EligibilityValue;
 
 pub struct EligibleRatioToEligiblityCount<T>(PhantomData<T>);
 
@@ -40,35 +41,38 @@ where
 	fn on_runtime_upgrade() -> Weight {
 		log::info!(target: "EligibleRatioToEligiblityCount", "starting migration");
 
-		if let Some(old_value) =
-			migration::get_storage_value::<Percent>(PALLET_NAME, ELIGIBLE_RATIO_ITEM_NAME, &[])
-		{
-			let total_authors = <T as Config>::PotentialAuthors::get().len();
-			let new_value: u32 = percent_of_num(old_value, total_authors as u32);
-			migration::put_storage_value(
-				PALLET_NAME,
-				ELIGIBLE_COUNT_ITEM_NAME,
-				&[],
-				NonZeroU32::new(new_value).unwrap_or(crate::pallet::DEFAULT_TOTAL_ELIGIBLE_AUTHORS),
-			);
+		let old_value =
+			migration::get_storage_value::<Percent>(PALLET_NAME, ELIGIBLE_RATIO_ITEM_NAME, &[]);
 
-			let db_weights = T::DbWeight::get();
-			db_weights.write + db_weights.read
-		} else {
-			0
-		}
+		let new_value = old_value
+			.and_then(|value| {
+				let total_authors = <T as Config>::PotentialAuthors::get().len();
+				let new_value = percent_of_num(value, total_authors as u32);
+				NonZeroU32::new(new_value)
+			})
+			.unwrap_or(EligibilityValue::default());
+
+		let db_weights = T::DbWeight::get();
+		migration::put_storage_value(PALLET_NAME, ELIGIBLE_COUNT_ITEM_NAME, &[], new_value);
+		db_weights.write + db_weights.read
 	}
 
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
-		if let Some(eligible_ratio) =
-			migration::get_storage_value::<Percent>(PALLET_NAME, ELIGIBLE_RATIO_ITEM_NAME, &[])
-		{
-			let total_authors = <T as Config>::PotentialAuthors::get().len();
-			let eligible_count: u32 = percent_of_num(eligible_ratio, total_authors as u32);
-			let eligible_count = NonZeroU32::new_unchecked(eligible_count);
-			Self::set_temp_storage(new_value, "expected_eligible_count");
-		}
+		let old_value =
+			migration::get_storage_value::<Percent>(PALLET_NAME, ELIGIBLE_RATIO_ITEM_NAME, &[]);
+
+		let expected_value = old_value
+			.and_then(|value| {
+				let total_authors = <T as Config>::PotentialAuthors::get().len();
+				let eligible_count: u32 = percent_of_num(value, total_authors as u32);
+				NonZeroU32::new(eligible_count)
+			})
+			.unwrap_or(EligibilityValue::default());
+
+		Self::set_temp_storage(expected_value, "expected_eligible_count");
+
+		Ok(())
 	}
 
 	#[cfg(feature = "try-runtime")]
@@ -78,9 +82,28 @@ where
 			migration::get_storage_value::<NonZeroU32>(PALLET_NAME, ELIGIBLE_COUNT_ITEM_NAME, &[]);
 
 		assert_eq!(expected, actual);
+
+		Ok(())
 	}
 }
 
 fn percent_of_num(percent: Percent, num: u32) -> u32 {
 	percent.mul_ceil(num as u32)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::percent_of_num;
+	use super::*;
+
+	#[test]
+	fn test_percent_of_num_ceils_value() {
+		let fifty_percent = Percent::from_float(0.5);
+
+		let actual = percent_of_num(fifty_percent, 5);
+		assert_eq!(3, actual);
+
+		let actual = percent_of_num(fifty_percent, 20);
+		assert_eq!(10, actual);
+	}
 }

--- a/pallets/author-slot-filter/src/tests.rs
+++ b/pallets/author-slot-filter/src/tests.rs
@@ -67,7 +67,7 @@ fn test_migration_works_for_converting_existing_eligible_ratio_to_eligible_count
 fn test_migration_works_for_converting_existing_zero_eligible_ratio_to_default_eligible_count() {
 	new_test_ext().execute_with(|| {
 		let input_eligible_ratio = Percent::from_percent(0);
-		let expected_eligible_count = DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
+		let expected_eligible_count = EligibilityValue::default();
 		let expected_weight = TestDbWeight::get().write + TestDbWeight::get().read;
 
 		put_storage_value(
@@ -88,11 +88,10 @@ fn test_migration_works_for_converting_existing_zero_eligible_ratio_to_default_e
 }
 
 #[test]
-fn test_migration_skips_converting_missing_eligible_ratio_to_eligible_count_and_returns_default_value(
-) {
+fn test_migration_inserts_default_value_for_missing_eligible_ratio() {
 	new_test_ext().execute_with(|| {
-		let expected_default_eligible_count = DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
-		let expected_weight = 0;
+		let expected_default_eligible_count = EligibilityValue::default();
+		let expected_weight = TestDbWeight::get().write + TestDbWeight::get().read;
 
 		let actual_weight = migration::EligibleRatioToEligiblityCount::<Test>::on_runtime_upgrade();
 		assert_eq!(expected_weight, actual_weight);

--- a/parachain-template/node/Cargo.toml
+++ b/parachain-template/node/Cargo.toml
@@ -98,3 +98,4 @@ substrate-build-script-utils = { git = "https://github.com/purestake/substrate",
 
 [features]
 runtime-benchmarks = [ "parachain-template-runtime/runtime-benchmarks" ]
+try-runtime = [ "parachain-template-runtime/try-runtime" ]

--- a/parachain-template/node/src/chain_spec.rs
+++ b/parachain-template/node/src/chain_spec.rs
@@ -181,7 +181,7 @@ fn testnet_genesis(
 		},
 		parachain_info: parachain_template_runtime::ParachainInfoConfig { parachain_id: id },
 		author_filter: parachain_template_runtime::AuthorFilterConfig {
-			eligible_count: parachain_template_runtime::DEFAULT_TOTAL_ELIGIBLE_AUTHORS,
+			eligible_count: parachain_template_runtime::EligibilityValue::default(),
 		},
 		potential_author_set: parachain_template_runtime::PotentialAuthorSetConfig {
 			mapping: authorities,

--- a/parachain-template/node/src/cli.rs
+++ b/parachain-template/node/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::chain_spec;
-use std::path::PathBuf;
 use clap::Parser;
+use std::path::PathBuf;
 
 /// Sub-commands supported by the collator.
 #[derive(Debug, Parser)]

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -13,8 +13,8 @@ use nimbus_consensus::{
 };
 
 // Cumulus Imports
-use cumulus_client_consensus_common::ParachainConsensus;
 use cumulus_client_cli::CollatorOptions;
+use cumulus_client_consensus_common::ParachainConsensus;
 use cumulus_client_network::BlockAnnounceValidator;
 use cumulus_client_service::{
 	prepare_node_config, start_collator, start_full_node, StartCollatorParams, StartFullNodeParams,
@@ -176,16 +176,21 @@ async fn build_relay_chain_interface(
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	task_manager: &mut TaskManager,
 	collator_options: CollatorOptions,
-	) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
+) -> RelayChainResult<(
+	Arc<(dyn RelayChainInterface + 'static)>,
+	Option<CollatorPair>,
+)> {
 	match collator_options.relay_chain_rpc_url {
-		Some(relay_chain_url) =>
-			Ok((Arc::new(RelayChainRPCInterface::new(relay_chain_url).await?) as Arc<_>, None)),
+		Some(relay_chain_url) => Ok((
+			Arc::new(RelayChainRPCInterface::new(relay_chain_url).await?) as Arc<_>,
+			None,
+		)),
 		None => build_inprocess_relay_chain(
 			polkadot_config,
 			parachain_config,
 			telemetry_worker_handle,
 			task_manager,
-			),
+		),
 	}
 }
 

--- a/parachain-template/runtime/Cargo.toml
+++ b/parachain-template/runtime/Cargo.toml
@@ -143,3 +143,8 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 ]
+
+try-runtime = [
+	"frame-support/try-runtime",
+	"pallet-author-slot-filter/try-runtime",
+]

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -17,8 +17,7 @@ use sp_runtime::{
 };
 
 pub use nimbus_primitives::NimbusId;
-
-pub use pallet_author_slot_filter::DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
+pub use pallet_author_slot_filter::EligibilityValue;
 
 use sp_std::prelude::*;
 #[cfg(feature = "std")]


### PR DESCRIPTION
This is a cherry pick of #43 onto v9.18

This PR changes the following in `author-slot-filter` pallet:

* Fixes migration so the `EligibilityValue` is written even if old value was missing from storage (previously it would have ignored writing it).
* Adds `try-runtime` feature so the migration can be tested
* Adds `default()` method (for no-std in runtime) instead of name constant
* Adds migration tests