### PR TITLE
[BUGFIX] Avoid magic strings during author-slot-filter migrations for storage access

### DIFF
--- a/pallets/author-slot-filter/src/migration.rs
+++ b/pallets/author-slot-filter/src/migration.rs
@@ -15,7 +15,6 @@
 // along with Nimbus.  If not, see <http://www.gnu.org/licenses/>.
 
 use core::marker::PhantomData;
-use frame_support::storage::migration;
 use frame_support::traits::Get;
 use frame_support::traits::OnRuntimeUpgrade;
 use frame_support::weights::Weight;
@@ -27,12 +26,10 @@ use frame_support::traits::OnRuntimeUpgradeHelpersExt;
 use super::num::NonZeroU32;
 use super::pallet::Config;
 use super::pallet::EligibilityValue;
+use super::pallet::EligibleCount;
+use super::pallet::Pallet;
 
 pub struct EligibleRatioToEligiblityCount<T>(PhantomData<T>);
-
-pub const PALLET_NAME: &[u8] = b"AuthorFilter";
-pub const ELIGIBLE_RATIO_ITEM_NAME: &[u8] = b"EligibleRatio";
-pub const ELIGIBLE_COUNT_ITEM_NAME: &[u8] = b"EligibleCount";
 
 impl<T> OnRuntimeUpgrade for EligibleRatioToEligiblityCount<T>
 where
@@ -41,34 +38,23 @@ where
 	fn on_runtime_upgrade() -> Weight {
 		log::info!(target: "EligibleRatioToEligiblityCount", "starting migration");
 
-		let old_value =
-			migration::get_storage_value::<Percent>(PALLET_NAME, ELIGIBLE_RATIO_ITEM_NAME, &[]);
+		let old_value = <Pallet<T>>::eligible_ratio();
+		let total_authors = <T as Config>::PotentialAuthors::get().len();
+		let new_value = percent_of_num(old_value, total_authors as u32);
+		let new_value = NonZeroU32::new(new_value).unwrap_or(EligibilityValue::default());
 
-		let new_value = old_value
-			.and_then(|value| {
-				let total_authors = <T as Config>::PotentialAuthors::get().len();
-				let new_value = percent_of_num(value, total_authors as u32);
-				NonZeroU32::new(new_value)
-			})
-			.unwrap_or(EligibilityValue::default());
+		<EligibleCount<T>>::put(new_value);
 
-		let db_weights = T::DbWeight::get();
-		migration::put_storage_value(PALLET_NAME, ELIGIBLE_COUNT_ITEM_NAME, &[], new_value);
-		db_weights.write + db_weights.read
+		T::DbWeight::get().reads_writes(1, 1)
 	}
 
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
-		let old_value =
-			migration::get_storage_value::<Percent>(PALLET_NAME, ELIGIBLE_RATIO_ITEM_NAME, &[]);
+		let old_value = <Pallet<T>>::eligible_ratio();
 
-		let expected_value = old_value
-			.and_then(|value| {
-				let total_authors = <T as Config>::PotentialAuthors::get().len();
-				let eligible_count: u32 = percent_of_num(value, total_authors as u32);
-				NonZeroU32::new(eligible_count)
-			})
-			.unwrap_or(EligibilityValue::default());
+		let total_authors = <T as Config>::PotentialAuthors::get().len();
+		let new_value = percent_of_num(old_value, total_authors as u32);
+		let expected_value = NonZeroU32::new(new_value).unwrap_or(EligibilityValue::default());
 
 		Self::set_temp_storage(expected_value, "expected_eligible_count");
 
@@ -78,8 +64,7 @@ where
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade() -> Result<(), &'static str> {
 		let expected = Self::get_temp_storage::<NonZeroU32>("expected_eligible_count");
-		let actual =
-			migration::get_storage_value::<NonZeroU32>(PALLET_NAME, ELIGIBLE_COUNT_ITEM_NAME, &[]);
+		let actual = <Pallet<T>>::eligible_count();
 
 		assert_eq!(expected, actual);
 
@@ -105,5 +90,16 @@ mod tests {
 
 		let actual = percent_of_num(fifty_percent, 20);
 		assert_eq!(10, actual);
+	}
+
+	#[test]
+	fn test_percent_of_num_hundred_percent_uses_full_value() {
+		let one_hundred_percent = Percent::from_float(1.0);
+
+		let actual = percent_of_num(one_hundred_percent, 5);
+		assert_eq!(5, actual);
+
+		let actual = percent_of_num(one_hundred_percent, 20);
+		assert_eq!(20, actual);
 	}
 }

--- a/pallets/author-slot-filter/src/migration.rs
+++ b/pallets/author-slot-filter/src/migration.rs
@@ -30,7 +30,7 @@ use super::pallet::EligibilityValue;
 
 pub struct EligibleRatioToEligiblityCount<T>(PhantomData<T>);
 
-pub const PALLET_NAME: &[u8] = b"AuthorSlotFilter";
+pub const PALLET_NAME: &[u8] = b"AuthorFilter";
 pub const ELIGIBLE_RATIO_ITEM_NAME: &[u8] = b"EligibleRatio";
 pub const ELIGIBLE_COUNT_ITEM_NAME: &[u8] = b"EligibleCount";
 

--- a/pallets/author-slot-filter/src/migration.rs
+++ b/pallets/author-slot-filter/src/migration.rs
@@ -42,7 +42,6 @@ where
 		let total_authors = <T as Config>::PotentialAuthors::get().len();
 		let new_value = percent_of_num(old_value, total_authors as u32);
 		let new_value = NonZeroU32::new(new_value).unwrap_or(EligibilityValue::default());
-
 		<EligibleCount<T>>::put(new_value);
 
 		T::DbWeight::get().reads_writes(1, 1)

--- a/pallets/author-slot-filter/src/tests.rs
+++ b/pallets/author-slot-filter/src/tests.rs
@@ -78,10 +78,13 @@ fn test_migration_works_for_converting_existing_zero_eligible_ratio_to_default_e
 	});
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_migration_inserts_default_value_for_missing_eligible_ratio() {
 	new_test_ext().execute_with(|| {
-		let expected_default_eligible_count = EligibilityValue::default();
+		let default_eligible_ratio = Percent::from_percent(50);
+		let expected_default_eligible_count =
+			NonZeroU32::new_unchecked(default_eligible_ratio.mul_ceil(Authors::get().len() as u32));
 		let expected_weight = TestDbWeight::get().write + TestDbWeight::get().read;
 
 		let actual_weight = migration::EligibleRatioToEligiblityCount::<Test>::on_runtime_upgrade();

--- a/pallets/author-slot-filter/src/tests.rs
+++ b/pallets/author-slot-filter/src/tests.rs
@@ -19,7 +19,6 @@ use crate::mock::*;
 use crate::num::NonZeroU32;
 
 use frame_support::assert_ok;
-use frame_support::migration::put_storage_value;
 use frame_support::traits::OnRuntimeUpgrade;
 use sp_runtime::Percent;
 
@@ -36,6 +35,7 @@ fn test_set_eligibility_works() {
 	});
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_migration_works_for_converting_existing_eligible_ratio_to_eligible_count() {
 	new_test_ext().execute_with(|| {
@@ -46,12 +46,7 @@ fn test_migration_works_for_converting_existing_eligible_ratio_to_eligible_count
 		let expected_eligible_count = NonZeroU32::new_unchecked(eligible_author_count);
 		let expected_weight = TestDbWeight::get().write + TestDbWeight::get().read;
 
-		put_storage_value(
-			migration::PALLET_NAME,
-			migration::ELIGIBLE_RATIO_ITEM_NAME,
-			&[],
-			input_eligible_ratio.clone(),
-		);
+		<EligibleRatio<Test>>::put(input_eligible_ratio.clone());
 
 		let actual_weight = migration::EligibleRatioToEligiblityCount::<Test>::on_runtime_upgrade();
 		assert_eq!(expected_weight, actual_weight);
@@ -63,6 +58,7 @@ fn test_migration_works_for_converting_existing_eligible_ratio_to_eligible_count
 	});
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_migration_works_for_converting_existing_zero_eligible_ratio_to_default_eligible_count() {
 	new_test_ext().execute_with(|| {
@@ -70,12 +66,7 @@ fn test_migration_works_for_converting_existing_zero_eligible_ratio_to_default_e
 		let expected_eligible_count = EligibilityValue::default();
 		let expected_weight = TestDbWeight::get().write + TestDbWeight::get().read;
 
-		put_storage_value(
-			migration::PALLET_NAME,
-			migration::ELIGIBLE_RATIO_ITEM_NAME,
-			&[],
-			input_eligible_ratio.clone(),
-		);
+		<EligibleRatio<Test>>::put(input_eligible_ratio.clone());
 
 		let actual_weight = migration::EligibleRatioToEligiblityCount::<Test>::on_runtime_upgrade();
 		assert_eq!(expected_weight, actual_weight);


### PR DESCRIPTION
The pallet prefix is `AuthorFilter` as defined in moonbeam. This PR uses the storage item programatically instead of using raw prefix strings.