### PR TITLE
auto force authoring when runtime change

### DIFF
--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -24,9 +24,9 @@
 use sp_application_crypto::KeyTypeId;
 use sp_runtime::traits::BlockNumberProvider;
 use sp_runtime::ConsensusEngineId;
-use sp_std::vec::Vec;
 #[cfg(feature = "runtime-benchmarks")]
 use sp_std::vec;
+use sp_std::vec::Vec;
 
 pub mod digests;
 mod inherents;
@@ -94,7 +94,7 @@ pub trait CanAuthor<AuthorId> {
 		vec![]
 	}
 	#[cfg(feature = "runtime-benchmarks")]
-	fn set_eligible_author(_slot: &u32) {} 
+	fn set_eligible_author(_slot: &u32) {}
 }
 /// Default implementation where anyone can author.
 ///

--- a/pallets/author-inherent/src/benchmarks.rs
+++ b/pallets/author-inherent/src/benchmarks.rs
@@ -17,7 +17,7 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use crate::{Call, Config, Pallet};
-use frame_benchmarking::{benchmarks};
+use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
 use nimbus_primitives::CanAuthor;
 use nimbus_primitives::SlotBeacon;

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -42,9 +42,9 @@ pub mod weights;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use crate::weights::WeightInfo;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use crate::weights::WeightInfo;
 
 	/// The Author Inherent pallet. The core of the nimbus consensus framework's runtime presence.
 	#[pallet::pallet]

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -138,11 +138,10 @@ pub mod pallet {
 			eligible.contains(author)
 		}
 		#[cfg(feature = "runtime-benchmarks")]
-		fn get_authors(slot: &u32) -> Vec<T::AccountId>  {
-		// Compute pseudo-random subset of potential authors
-		let (eligible, _) =
-			compute_pseudo_random_subset::<T>(T::PotentialAuthors::get(), slot);
-		eligible
+		fn get_authors(slot: &u32) -> Vec<T::AccountId> {
+			// Compute pseudo-random subset of potential authors
+			let (eligible, _) = compute_pseudo_random_subset::<T>(T::PotentialAuthors::get(), slot);
+			eligible
 		}
 	}
 


### PR DESCRIPTION
The force-authoring code doesn't exist anymore, it seems to have been deleted by mistake when migrating the nimbus code into its own repository.

Indeed, I added the auto force-authoring at the time when the nimbus code was still in our cumulus fork: https://github.com/PureStake/cumulus/pull/3/files