### PR TITLE
fix try-runtime compile

### DIFF
--- a/pallets/author-slot-filter/src/migration.rs
+++ b/pallets/author-slot-filter/src/migration.rs
@@ -62,7 +62,8 @@ where
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade() -> Result<(), &'static str> {
-		let expected = Self::get_temp_storage::<NonZeroU32>("expected_eligible_count");
+		let expected = Self::get_temp_storage::<NonZeroU32>("expected_eligible_count")
+			.expect("value must exist");
 		let actual = <Pallet<T>>::eligible_count();
 
 		assert_eq!(expected, actual);


### PR DESCRIPTION
This is a cherry-pick of #56 which fixes the build with `--features try-runtime`. It was broken due to an incorrect type assert.