### PR TITLE
Add inherent digests provider (to insert Vrf Digest in Moonbeam)

### DIFF
--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -27,8 +27,7 @@ use cumulus_primitives_core::{relay_chain::v2::Hash as PHash, ParaId, PersistedV
 pub use import_queue::import_queue;
 use log::{debug, info, warn};
 use nimbus_primitives::{
-	AuthorFilterAPI, CompatibleDigestItem, InherentDigestsProvider, NimbusApi, NimbusId,
-	NIMBUS_KEY_ID,
+	AuthorFilterAPI, CompatibleDigestItem, DigestsProvider, NimbusApi, NimbusId, NIMBUS_KEY_ID,
 };
 use parking_lot::Mutex;
 use sc_consensus::{BlockImport, BlockImportParams};
@@ -88,7 +87,7 @@ where
 	BI: 'static,
 	ParaClient: ProvideRuntimeApi<B> + 'static,
 	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData, NimbusId)> + 'static,
-	DP: InherentDigestsProvider<NimbusId, <B as BlockT>::Hash> + 'static,
+	DP: DigestsProvider<NimbusId, <B as BlockT>::Hash> + 'static,
 {
 	/// Create a new instance of nimbus consensus.
 	pub fn build(
@@ -313,7 +312,7 @@ where
 	ParaClient::Api: AuthorFilterAPI<B, NimbusId>,
 	ParaClient::Api: NimbusApi<B>,
 	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData, NimbusId)> + 'static,
-	DP: InherentDigestsProvider<NimbusId, <B as BlockT>::Hash> + 'static + Send + Sync,
+	DP: DigestsProvider<NimbusId, <B as BlockT>::Hash> + 'static + Send + Sync,
 {
 	async fn produce_candidate(
 		&mut self,
@@ -386,7 +385,7 @@ where
 		let mut logs = vec![CompatibleDigestItem::nimbus_pre_digest(nimbus_id.clone())];
 		logs.extend(
 			self.additional_digests_provider
-				.provide_inherent_digests(nimbus_id, parent.hash()),
+				.provide_digests(nimbus_id, parent.hash()),
 		);
 		let inherent_digests = sp_runtime::generic::Digest { logs };
 

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -53,7 +53,7 @@ pub use manual_seal::NimbusManualSealConsensusDataProvider;
 const LOG_TARGET: &str = "filtering-consensus";
 
 /// The implementation of the relay-chain provided consensus for parachains.
-pub struct NimbusConsensus<B, PF, BI, ParaClient, CIDP, DP> {
+pub struct NimbusConsensus<B, PF, BI, ParaClient, CIDP, DP = ()> {
 	para_id: ParaId,
 	proposer_factory: Arc<Mutex<PF>>,
 	create_inherent_data_providers: Arc<CIDP>,

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -61,7 +61,7 @@ pub struct NimbusConsensus<B, PF, BI, ParaClient, CIDP, DP> {
 	parachain_client: Arc<ParaClient>,
 	keystore: SyncCryptoStorePtr,
 	skip_prediction: bool,
-	additional_digests_provider: Option<Arc<DP>>,
+	additional_digests_provider: Arc<DP>,
 	_phantom: PhantomData<B>,
 }
 
@@ -116,7 +116,7 @@ where
 			parachain_client,
 			keystore,
 			skip_prediction,
-			additional_digests_provider: additional_digests_provider.map(|x| Arc::new(x)),
+			additional_digests_provider: Arc::new(additional_digests_provider),
 			_phantom: PhantomData,
 		})
 	}
@@ -471,5 +471,5 @@ pub struct BuildNimbusConsensusParams<PF, BI, ParaClient, CIDP, DP> {
 	pub parachain_client: Arc<ParaClient>,
 	pub keystore: SyncCryptoStorePtr,
 	pub skip_prediction: bool,
-	pub additional_digests_provider: Option<DP>,
+	pub additional_digests_provider: DP,
 }

--- a/nimbus-consensus/src/lib.rs
+++ b/nimbus-consensus/src/lib.rs
@@ -383,11 +383,14 @@ where
 			)
 			.await?;
 
-		let maybe_digest_provider = self.additional_digests_provider.as_ref();
 		let mut logs = vec![CompatibleDigestItem::nimbus_pre_digest(nimbus_id.clone())];
-		if let Some(digest_provider) = maybe_digest_provider {
-			logs.append(&mut digest_provider.provide_inherent_digests(nimbus_id));
-		};
+		for digest in self
+			.additional_digests_provider
+			.provide_inherent_digests(nimbus_id)
+			.into_iter()
+		{
+			logs.push(digest);
+		}
 		let inherent_digests = sp_runtime::generic::Digest { logs };
 
 		let Proposal {

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -36,27 +36,26 @@ pub use digests::CompatibleDigestItem;
 
 pub use inherents::{InherentDataProvider, INHERENT_IDENTIFIER};
 
-/// Input NimbusId and returns the additional inherent digests
 pub trait DigestsProvider<Id, BlockHash> {
 	type Digests: IntoIterator<Item = DigestItem>;
 	fn provide_digests(&self, id: Id, parent: BlockHash) -> Self::Digests;
 }
 
-impl<Id, BlockHash> InherentDigestsProvider<Id, BlockHash> for () {
+impl<Id, BlockHash> DigestsProvider<Id, BlockHash> for () {
 	type Digests = [DigestItem; 0];
-	fn provide_inherent_digests(&self, _id: Id, _parent: BlockHash) -> Self::Digests {
+	fn provide_digests(&self, _id: Id, _parent: BlockHash) -> Self::Digests {
 		[]
 	}
 }
 
-impl<F, Id, BlockHash, D> InherentDigestsProvider<Id, BlockHash> for F
+impl<F, Id, BlockHash, D> DigestsProvider<Id, BlockHash> for F
 where
 	F: Fn(Id, BlockHash) -> D,
 	D: IntoIterator<Item = DigestItem>,
 {
 	type Digests = D;
 
-	fn provide_inherent_digests(&self, id: Id, parent: BlockHash) -> Self::Digests {
+	fn provide_digests(&self, id: Id, parent: BlockHash) -> Self::Digests {
 		(*self)(id, parent)
 	}
 }

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -38,11 +38,13 @@ pub use inherents::{InherentDataProvider, INHERENT_IDENTIFIER};
 
 /// Input NimbusId and returns the additional inherent digests
 pub trait InherentDigestsProvider<Id> {
-	fn provide_inherent_digests(&self, id: Id) -> Vec<DigestItem>;
+	type Digests: IntoIterator<Item = DigestItem>;
+	fn provide_inherent_digests(&self, id: Id) -> Self::Digests;
 }
 
 impl<Id> InherentDigestsProvider<Id> for () {
-	fn provide_inherent_digests(&self, _id: Id) -> Vec<DigestItem> {
+	type Digests = Vec<DigestItem>;
+	fn provide_inherent_digests(&self, _id: Id) -> Self::Digests {
 		Vec::new()
 	}
 }

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -22,6 +22,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_application_crypto::KeyTypeId;
+use sp_runtime::generic::DigestItem;
 use sp_runtime::traits::BlockNumberProvider;
 use sp_runtime::ConsensusEngineId;
 #[cfg(feature = "runtime-benchmarks")]
@@ -34,6 +35,17 @@ mod inherents;
 pub use digests::CompatibleDigestItem;
 
 pub use inherents::{InherentDataProvider, INHERENT_IDENTIFIER};
+
+/// Input NimbusId and returns the additional inherent digests
+pub trait InherentDigestsProvider<Id> {
+	fn provide_inherent_digests(&self, id: Id) -> Vec<DigestItem>;
+}
+
+impl<Id> InherentDigestsProvider<Id> for () {
+	fn provide_inherent_digests(&self, _id: Id) -> Vec<DigestItem> {
+		Vec::new()
+	}
+}
 
 /// The given account ID is the author of the current block.
 pub trait EventHandler<Author> {

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -43,9 +43,9 @@ pub trait InherentDigestsProvider<Id> {
 }
 
 impl<Id> InherentDigestsProvider<Id> for () {
-	type Digests = Vec<DigestItem>;
+	type Digests = [DigestItem; 0];
 	fn provide_inherent_digests(&self, _id: Id) -> Self::Digests {
-		Vec::new()
+		[]
 	}
 }
 

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -37,9 +37,9 @@ pub use digests::CompatibleDigestItem;
 pub use inherents::{InherentDataProvider, INHERENT_IDENTIFIER};
 
 /// Input NimbusId and returns the additional inherent digests
-pub trait InherentDigestsProvider<Id, BlockHash> {
+pub trait DigestsProvider<Id, BlockHash> {
 	type Digests: IntoIterator<Item = DigestItem>;
-	fn provide_inherent_digests(&self, id: Id, parent: BlockHash) -> Self::Digests;
+	fn provide_digests(&self, id: Id, parent: BlockHash) -> Self::Digests;
 }
 
 impl<Id, BlockHash> InherentDigestsProvider<Id, BlockHash> for () {

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -37,15 +37,27 @@ pub use digests::CompatibleDigestItem;
 pub use inherents::{InherentDataProvider, INHERENT_IDENTIFIER};
 
 /// Input NimbusId and returns the additional inherent digests
-pub trait InherentDigestsProvider<Id> {
+pub trait InherentDigestsProvider<Id, BlockHash> {
 	type Digests: IntoIterator<Item = DigestItem>;
-	fn provide_inherent_digests(&self, id: Id) -> Self::Digests;
+	fn provide_inherent_digests(&self, id: Id, parent: BlockHash) -> Self::Digests;
 }
 
-impl<Id> InherentDigestsProvider<Id> for () {
+impl<Id, BlockHash> InherentDigestsProvider<Id, BlockHash> for () {
 	type Digests = [DigestItem; 0];
-	fn provide_inherent_digests(&self, _id: Id) -> Self::Digests {
+	fn provide_inherent_digests(&self, _id: Id, _parent: BlockHash) -> Self::Digests {
 		[]
+	}
+}
+
+impl<F, Id, BlockHash, D> InherentDigestsProvider<Id, BlockHash> for F
+where
+	F: Fn(Id, BlockHash) -> D,
+	D: IntoIterator<Item = DigestItem>,
+{
+	type Digests = D;
+
+	fn provide_inherent_digests(&self, id: Id, parent: BlockHash) -> Self::Digests {
+		(*self)(id, parent)
 	}
 }
 

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -449,6 +449,7 @@ pub async fn start_parachain_node(
 						Ok((time, parachain_inherent, nimbus_inherent))
 					}
 				},
+				additional_digests_provider: None,
 			}))
 		},
 	)

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -449,7 +449,7 @@ pub async fn start_parachain_node(
 						Ok((time, parachain_inherent, nimbus_inherent))
 					}
 				},
-				additional_digests_provider: None,
+				additional_digests_provider: Some(()),
 			}))
 		},
 	)

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -449,7 +449,7 @@ pub async fn start_parachain_node(
 						Ok((time, parachain_inherent, nimbus_inherent))
 					}
 				},
-				additional_digests_provider: Some(()),
+				additional_digests_provider: (),
 			}))
 		},
 	)


### PR DESCRIPTION
We need to insert a Vrf PreDigest { VrfOutput, VrfProof } in Moonbeam for the VRF so we need to add this new trait and struct field

https://github.com/PureStake/moonbeam/pull/1376#discussion_r904287533

An alternative considered was moving the Vrf client primitives into Nimbus and use it directly in nimbus-consensus but I prefer the approach in this PR proposed by @librelois  