### PR TITLE
Add runtime API and keystore as inputs to provide_digests

### DIFF
--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -36,27 +36,48 @@ pub use digests::CompatibleDigestItem;
 
 pub use inherents::{InherentDataProvider, INHERENT_IDENTIFIER};
 
-pub trait DigestsProvider<Id, BlockHash> {
+pub trait DigestsProvider<Id, BlockHash, RuntimeApi, KeyStore> {
 	type Digests: IntoIterator<Item = DigestItem>;
-	fn provide_digests(&self, id: Id, parent: BlockHash) -> Self::Digests;
+	fn provide_digests(
+		&self,
+		id: Id,
+		parent: BlockHash,
+		runtime_api: RuntimeApi,
+		keystore: KeyStore,
+	) -> Self::Digests;
 }
 
-impl<Id, BlockHash> DigestsProvider<Id, BlockHash> for () {
+impl<Id, BlockHash, RuntimeApi, KeyStore> DigestsProvider<Id, BlockHash, RuntimeApi, KeyStore>
+	for ()
+{
 	type Digests = [DigestItem; 0];
-	fn provide_digests(&self, _id: Id, _parent: BlockHash) -> Self::Digests {
+	fn provide_digests(
+		&self,
+		_id: Id,
+		_parent: BlockHash,
+		_runtime_api: RuntimeApi,
+		_key_store: KeyStore,
+	) -> Self::Digests {
 		[]
 	}
 }
 
-impl<F, Id, BlockHash, D> DigestsProvider<Id, BlockHash> for F
+impl<F, Id, BlockHash, RuntimeApi, KeyStore, D> DigestsProvider<Id, BlockHash, RuntimeApi, KeyStore>
+	for F
 where
-	F: Fn(Id, BlockHash) -> D,
+	F: Fn(Id, BlockHash, RuntimeApi, KeyStore) -> D,
 	D: IntoIterator<Item = DigestItem>,
 {
 	type Digests = D;
 
-	fn provide_digests(&self, id: Id, parent: BlockHash) -> Self::Digests {
-		(*self)(id, parent)
+	fn provide_digests(
+		&self,
+		id: Id,
+		parent: BlockHash,
+		runtime_api: RuntimeApi,
+		key_store: KeyStore,
+	) -> Self::Digests {
+		(*self)(id, parent, runtime_api, key_store)
 	}
 }
 


### PR DESCRIPTION
Ref: https://github.com/PureStake/moonbeam/pull/1376#discussion_r906937012

Not working yet:
```rust
error[E0507]: cannot move out of a shared reference
   --> nimbus-consensus/src/lib.rs:389:48
    |
389 |                 .provide_digests(nimbus_id, parent.hash(), *runtime_api_client.clone(), *&self.keystore),
    |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `ParaClient`, which does not implement the `Copy` trait

error[E0507]: cannot move out of a shared reference
   --> nimbus-consensus/src/lib.rs:389:77
    |
389 |                 .provide_digests(nimbus_id, parent.hash(), *runtime_api_client.clone(), *&self.keystore),
    |                                                                                         ^^^^^^^^^^^^^^^ move occurs because value has type `Arc<dyn SyncCryptoStore>`, which does not implement the `Copy` trait

For more information about this error, try `rustc --explain E0507`.
error: could not compile `nimbus-consensus` due to 2 previous errors
```