### PR TITLE
Changes before re-running benchmarking

### DIFF
--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -104,19 +104,16 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(_: T::BlockNumber) -> Weight {
-			// Start by clearing out the previous block's author
-			<Author<T>>::kill();
-
-			// Now extract the author from the digest
+			// Extract the author from the digest
 			let digest = <frame_system::Pallet<T>>::digest();
 
 			let pre_runtime_digests = digest.logs.iter().filter_map(|d| d.as_pre_runtime());
-			if let Some(author_account) = Self::find_author(pre_runtime_digests) {
-				// Store the author so we can confirm eligibility after the inherents have executed
-				<Author<T>>::put(&author_account);
-			}
+			let author_account = Self::find_author(pre_runtime_digests)
+				.expect("Block invalid, no authorship information supplied in pre-runtime digest.");
+			// Store the author so we can confirm eligibility after the inherents have executed
+			<Author<T>>::put(&author_account);
 
-			T::DbWeight::get().write * 2
+			T::DbWeight::get().write
 		}
 	}
 


### PR DESCRIPTION
Base branch #70 

There is already a panic in `kick_off_...` inherent if `Author` storage item isn't set so we can panic in `on_initialize` if `Author` storage item cannot be set. This moves the panic up but the panic would happen either way. If there is another place `Author` can be set, let me know but I don't think there is.

I moved this into its own PR because these changes aren't essential to the base PR.