### PR TITLE
Remove EventHandler trait and expose block author directly

### DIFF
--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -60,11 +60,6 @@ where
 	}
 }
 
-/// Return current block author without passing any input
-pub trait GetAuthor<AccountId> {
-	fn get_author() -> AccountId;
-}
-
 /// The given account ID is the author of the current block.
 pub trait EventHandler<Author> {
 	//TODO should we be tking ownership here?

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -60,6 +60,11 @@ where
 	}
 }
 
+/// Return current block author without passing any input
+pub trait GetAuthor<AccountId> {
+	fn get_author() -> AccountId;
+}
+
 /// The given account ID is the author of the current block.
 pub trait EventHandler<Author> {
 	//TODO should we be tking ownership here?

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -20,10 +20,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::traits::FindAuthor;
+use frame_support::traits::{FindAuthor, Get};
 use nimbus_primitives::{
-	AccountLookup, CanAuthor, GetAuthor, NimbusId, SlotBeacon, INHERENT_IDENTIFIER,
-	NIMBUS_ENGINE_ID,
+	AccountLookup, CanAuthor, NimbusId, SlotBeacon, INHERENT_IDENTIFIER, NIMBUS_ENGINE_ID,
 };
 use parity_scale_codec::{Decode, Encode};
 use sp_inherents::{InherentIdentifier, IsFatalError};
@@ -132,7 +131,7 @@ pub mod pallet {
 
 			// Now check that the author is valid in this slot
 			assert!(
-				T::CanAuthor::can_author(&Self::get_author(), &slot),
+				T::CanAuthor::can_author(&Self::get(), &slot),
 				"Block invalid, supplied author is not eligible."
 			);
 
@@ -191,8 +190,8 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> GetAuthor<T::AccountId> for Pallet<T> {
-		fn get_author() -> T::AccountId {
+	impl<T: Config> Get<T::AccountId> for Pallet<T> {
+		fn get() -> T::AccountId {
 			Author::<T>::get().expect("Block author not inserted into Author Inherent Pallet")
 		}
 	}

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -131,10 +131,8 @@ pub mod pallet {
 			);
 
 			// Now check that the author is valid in this slot
-			let author = <Author<T>>::get()
-				.expect("Block invalid, no authorship information supplied in preruntime digest.");
 			assert!(
-				T::CanAuthor::can_author(&author, &slot),
+				T::CanAuthor::can_author(&Self::get_author(), &slot),
 				"Block invalid, supplied author is not eligible."
 			);
 

--- a/pallets/author-inherent/src/mock.rs
+++ b/pallets/author-inherent/src/mock.rs
@@ -84,7 +84,6 @@ impl nimbus_primitives::SlotBeacon for DummyBeacon {
 
 impl pallet_testing::Config for Test {
 	type AccountLookup = ();
-	type EventHandler = ();
 	type CanAuthor = ();
 	type SlotBeacon = DummyBeacon;
 	type WeightInfo = ();

--- a/pallets/author-inherent/src/mock.rs
+++ b/pallets/author-inherent/src/mock.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Nimbus.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate as pallet_testing;
+use crate::{self as pallet_testing, AccountLookup, NimbusId};
 use frame_support::parameter_types;
 use frame_support::traits::ConstU32;
 use frame_support::weights::RuntimeDbWeight;
@@ -82,9 +82,32 @@ impl nimbus_primitives::SlotBeacon for DummyBeacon {
 	}
 }
 
+pub const ALICE: u64 = 1;
+pub const ALICE_NIMBUS: [u8; 32] = [1; 32];
+pub struct MockAccountLookup;
+impl AccountLookup<u64> for MockAccountLookup {
+	fn lookup_account(nimbus_id: &NimbusId) -> Option<u64> {
+		let nimbus_id_bytes: &[u8] = nimbus_id.as_ref();
+
+		if nimbus_id_bytes == &ALICE_NIMBUS {
+			Some(ALICE)
+		} else {
+			None
+		}
+	}
+}
+
 impl pallet_testing::Config for Test {
-	type AccountLookup = ();
+	type AccountLookup = MockAccountLookup;
 	type CanAuthor = ();
 	type SlotBeacon = DummyBeacon;
 	type WeightInfo = ();
+}
+
+/// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap()
+		.into()
 }

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -550,7 +550,6 @@ impl pallet_author_inherent::Config for Runtime {
 	// We start a new slot each time we see a new relay block.
 	type SlotBeacon = cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;
 	type AccountLookup = PotentialAuthorSet;
-	type EventHandler = ();
 	type CanAuthor = AuthorFilter;
 	type WeightInfo = ();
 }


### PR DESCRIPTION
We made a decision to move `note_author` into `on_finalize` in staking and removing it from nimbus altogether.

Read the associated moonbeam PR 1701 which mentions this PR below (for the link)