### PR TITLE
Use more bytes from index, seed for author-slot-filter random input

### DIFF
--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -99,9 +99,9 @@ pub mod pallet {
 			let mut first_four_bytes_of_seed = &seed.to_be_bytes()[..4];
 			let mut constant_string: [u8; 6] = [b'f', b'i', b'l', b't', b'e', b'r'];
 			let mut subject: [u8; 12] = [0u8; 12];
-			subject.copy_from_slice(&mut constant_string);
-			subject.copy_from_slice(&mut first_two_bytes_of_index);
-			subject.copy_from_slice(&mut first_four_bytes_of_seed);
+			subject[..6].copy_from_slice(&mut constant_string);
+			subject[6..8].copy_from_slice(&mut first_two_bytes_of_index);
+			subject[8..].copy_from_slice(&mut first_four_bytes_of_seed);
 			let (randomness, _) = T::RandomnessSource::random(&subject);
 			debug!(target: "author-filter", "🎲Randomness sample {}: {:?}", i, &randomness);
 

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -94,17 +94,17 @@ pub mod pallet {
 			// A context identifier for grabbing the randomness. Consists of three parts
 			// - The constant string *b"filter" - to identify this pallet
 			// - The index `i` when we're selecting the ith eligible author
-			// we take the last 2 bytes of index.to_be_bytes
+			// we take the first 2 bytes of index.to_be_bytes
 			// we take the first 4 bytes of seed.to_be_bytes
 			// - The relay parent block number so that the eligible authors at the next height
 			//   change. Avoids liveness attacks from colluding minorities of active authors.
 			// Third one may not be necessary once we leverage the relay chain's randomness.
-			let mut last_two_bytes_of_index = &i.to_be_bytes()[7..];
-			let mut first_four_bytes_of_seed = &seed.to_be_bytes()[0..4];
+			let mut first_two_bytes_of_index = &i.to_be_bytes()[..2];
+			let mut first_four_bytes_of_seed = &seed.to_be_bytes()[..4];
 			let mut constant_string: [u8; 6] = [b'f', b'i', b'l', b't', b'e', b'r'];
 			let mut subject: [u8; 12] = [0u8; 12];
 			subject.copy_from_slice(&mut constant_string);
-			subject.copy_from_slice(&mut last_two_bytes_of_index);
+			subject.copy_from_slice(&mut first_two_bytes_of_index);
 			subject.copy_from_slice(&mut first_four_bytes_of_seed);
 			let (randomness, _) = T::RandomnessSource::random(&subject);
 			debug!(target: "author-filter", "🎲Randomness sample {}: {:?}", i, &randomness);

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -92,13 +92,9 @@ pub mod pallet {
 
 		for i in 0..num_eligible {
 			// A context identifier for grabbing the randomness. Consists of three parts
-			// - The constant string *b"filter" - to identify this pallet
-			// - The index `i` when we're selecting the ith eligible author
-			// we take the first 2 bytes of index.to_be_bytes
-			// we take the first 4 bytes of seed.to_be_bytes
-			// - The relay parent block number so that the eligible authors at the next height
-			//   change. Avoids liveness attacks from colluding minorities of active authors.
-			// Third one may not be necessary once we leverage the relay chain's randomness.
+			// 1. Constant string *b"filter" - to identify this pallet
+			// 2. First 2 bytes of index.to_be_bytes when selecting the ith eligible author
+			// 3. First 4 bytes of seed.to_be_bytes
 			let mut first_two_bytes_of_index = &i.to_be_bytes()[..2];
 			let mut first_four_bytes_of_seed = &seed.to_be_bytes()[..4];
 			let mut constant_string: [u8; 6] = [b'f', b'i', b'l', b't', b'e', b'r'];

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -94,10 +94,18 @@ pub mod pallet {
 			// A context identifier for grabbing the randomness. Consists of three parts
 			// - The constant string *b"filter" - to identify this pallet
 			// - The index `i` when we're selecting the ith eligible author
+			// we take the last 2 bytes of index.to_be_bytes
+			// we take the first 4 bytes of seed.to_be_bytes
 			// - The relay parent block number so that the eligible authors at the next height
 			//   change. Avoids liveness attacks from colluding minorities of active authors.
 			// Third one may not be necessary once we leverage the relay chain's randomness.
-			let subject: [u8; 8] = [b'f', b'i', b'l', b't', b'e', b'r', i as u8, *seed as u8];
+			let mut last_two_bytes_of_index = &i.to_be_bytes()[7..];
+			let mut first_four_bytes_of_seed = &seed.to_be_bytes()[0..4];
+			let mut constant_string: [u8; 6] = [b'f', b'i', b'l', b't', b'e', b'r'];
+			let mut subject: [u8; 12] = [0u8; 12];
+			subject.copy_from_slice(&mut constant_string);
+			subject.copy_from_slice(&mut last_two_bytes_of_index);
+			subject.copy_from_slice(&mut first_four_bytes_of_seed);
 			let (randomness, _) = T::RandomnessSource::random(&subject);
 			debug!(target: "author-filter", "🎲Randomness sample {}: {:?}", i, &randomness);
 


### PR DESCRIPTION
Following NCC recommendation, uses 2 bytes from the index and 4 bytes from the seed for the input to `T::RandomnessSource::random`. Specifically, takes the first 2 bytes of index.to_be_bytes and the first 4 bytes of seed.to_be_bytes.

From the NCC audit: "Not utilizing all of the given seed bytes and the potential for a repeating index byte reduces the differentiating range of the constructed subject argument"