### PR TITLE
feat(try-runtime): skip author eligibility with try-runtime

### DIFF
--- a/nimbus-primitives/Cargo.toml
+++ b/nimbus-primitives/Cargo.toml
@@ -36,3 +36,5 @@ std = [
 ]
 
 runtime-benchmarks = [ "frame-benchmarking", "sp-runtime/runtime-benchmarks" ]
+
+try-runtime = [ "frame-support/try-runtime" ]

--- a/nimbus-primitives/src/lib.rs
+++ b/nimbus-primitives/src/lib.rs
@@ -113,6 +113,12 @@ impl SlotBeacon for IntervalBeacon {
 /// There may be another variant where the caller only supplies a slot and the
 /// implementation replies with a complete set of eligible authors.
 pub trait CanAuthor<AuthorId> {
+	#[cfg(feature = "try-runtime")]
+	// With `try-runtime` the local author should always be able to author a block.
+	fn can_author(author: &AuthorId, slot: &u32) -> bool {
+		true
+	}
+	#[cfg(not(feature = "try-runtime"))]
 	fn can_author(author: &AuthorId, slot: &u32) -> bool;
 	#[cfg(feature = "runtime-benchmarks")]
 	fn get_authors(_slot: &u32) -> Vec<AuthorId> {

--- a/pallets/aura-style-filter/Cargo.toml
+++ b/pallets/aura-style-filter/Cargo.toml
@@ -30,4 +30,4 @@ std = [
 	"sp-std/std",
 ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = [ "frame-support/try-runtime", "nimbus-primitives/try-runtime" ]

--- a/pallets/aura-style-filter/Cargo.toml
+++ b/pallets/aura-style-filter/Cargo.toml
@@ -29,3 +29,5 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
+
+try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/aura-style-filter/src/lib.rs
+++ b/pallets/aura-style-filter/src/lib.rs
@@ -66,11 +66,6 @@ pub mod pallet {
 	// of this block is eligible at this slot. We calculate that result on demand and do not
 	// record it instorage.
 	impl<T: Config> nimbus_primitives::CanAuthor<T::AccountId> for Pallet<T> {
-		#[cfg(feature = "try-runtime")]
-		// With `try-runtime` the local author should always be able to author a block.
-		fn can_author(author: &T::AccountId, slot: &u32) -> bool {
-			true
-		}
 		#[cfg(not(feature = "try-runtime"))]
 		fn can_author(account: &T::AccountId, slot: &u32) -> bool {
 			let active: Vec<T::AccountId> = T::PotentialAuthors::get();

--- a/pallets/aura-style-filter/src/lib.rs
+++ b/pallets/aura-style-filter/src/lib.rs
@@ -66,6 +66,12 @@ pub mod pallet {
 	// of this block is eligible at this slot. We calculate that result on demand and do not
 	// record it instorage.
 	impl<T: Config> nimbus_primitives::CanAuthor<T::AccountId> for Pallet<T> {
+		#[cfg(feature = "try-runtime")]
+		// With `try-runtime` the local author should always be able to author a block.
+		fn can_author(author: &T::AccountId, slot: &u32) -> bool {
+			true
+		}
+		#[cfg(not(feature = "try-runtime"))]
 		fn can_author(account: &T::AccountId, slot: &u32) -> bool {
 			let active: Vec<T::AccountId> = T::PotentialAuthors::get();
 

--- a/pallets/author-slot-filter/Cargo.toml
+++ b/pallets/author-slot-filter/Cargo.toml
@@ -42,4 +42,4 @@ std = [
 
 runtime-benchmarks = [ "frame-benchmarking", "nimbus-primitives/runtime-benchmarks" ]
 
-try-runtime = [ "frame-support/try-runtime" ]
+try-runtime = [ "frame-support/try-runtime", "nimbus-primitives/try-runtime" ]

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -125,11 +125,6 @@ pub mod pallet {
 	// of this block is eligible in this slot. We calculate that result on demand and do not
 	// record it in storage (although we do emit a debugging event for now).
 	impl<T: Config> CanAuthor<T::AccountId> for Pallet<T> {
-		#[cfg(feature = "try-runtime")]
-		// With `try-runtime` the local author should always be able to author a block.
-		fn can_author(author: &T::AccountId, slot: &u32) -> bool {
-			true
-		}
 		#[cfg(not(feature = "try-runtime"))]
 		fn can_author(author: &T::AccountId, slot: &u32) -> bool {
 			// Compute pseudo-random subset of potential authors

--- a/pallets/author-slot-filter/src/lib.rs
+++ b/pallets/author-slot-filter/src/lib.rs
@@ -125,6 +125,12 @@ pub mod pallet {
 	// of this block is eligible in this slot. We calculate that result on demand and do not
 	// record it in storage (although we do emit a debugging event for now).
 	impl<T: Config> CanAuthor<T::AccountId> for Pallet<T> {
+		#[cfg(feature = "try-runtime")]
+		// With `try-runtime` the local author should always be able to author a block.
+		fn can_author(author: &T::AccountId, slot: &u32) -> bool {
+			true
+		}
+		#[cfg(not(feature = "try-runtime"))]
 		fn can_author(author: &T::AccountId, slot: &u32) -> bool {
 			// Compute pseudo-random subset of potential authors
 			let (eligible, ineligible) =


### PR DESCRIPTION
To be able to use `try runtime follow-chain` with a nimbus based blockchain, the local author should always be able to author a block.