### PR TITLE
Generic AuthorId in author-inherent pallet

### DIFF
--- a/pallets/author-inherent/src/mock.rs
+++ b/pallets/author-inherent/src/mock.rs
@@ -98,6 +98,7 @@ impl AccountLookup<u64> for MockAccountLookup {
 }
 
 impl pallet_testing::Config for Test {
+	type AuthorId = u64;
 	type AccountLookup = MockAccountLookup;
 	type CanAuthor = ();
 	type SlotBeacon = DummyBeacon;

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -577,6 +577,7 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 }
 
 impl pallet_author_inherent::Config for Runtime {
+	type AuthorId = AccountId;
 	// We start a new slot each time we see a new relay block.
 	type SlotBeacon = cumulus_pallet_parachain_system::RelaychainDataProvider<Self>;
 	type AccountLookup = PotentialAuthorSet;


### PR DESCRIPTION
Make author-inherent pallet generic over the type of the author id, instead of forcing using AccountId. This can be useful for chains having authors without an AccountId.

## Breaking changes
Adds a new associated type `AuthorId`. Existing implementors should simply add `type AuthorId = AccountId` in their impl.