### PR TITLE
Pass through try-runtime feature in pallet-author-inherent

### DIFF
--- a/pallets/author-inherent/Cargo.toml
+++ b/pallets/author-inherent/Cargo.toml
@@ -48,3 +48,8 @@ runtime-benchmarks = [
 	"frame-benchmarking",
 	"nimbus-primitives/runtime-benchmarks",
 ]
+
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime"
+]


### PR DESCRIPTION
When trying to build the Zeitgeist runtime with the `try-runtime` feature, it fails because `pallet-author-inherent` does not pass through this feature properly.

<details>
  <summary>
  Click here to expand the error message
  </summary>
<pre>
<code>
  error[E0599]: the function or associated item `try_execute_block` exists for struct `Executive<Runtime, Block<Header<u64, BlakeTwo256>, UncheckedExtrinsic<..., ..., ..., ...>>, ..., ..., ...>`, but its trait bounds were not satisfied
     --> /home/sea212/Documents/github/zeitgeist/runtime/zeitgeist/src/lib.rs:223:1
      |
  223 | create_runtime_api!();
      | ^^^^^^^^^^^^^^^^^^^^^ function or associated item cannot be called due to unsatisfied trait bounds
      |
      = note: the full type name has been written to '/home/sea212/Documents/github/zeitgeist/target/debug/wbuild/zeitgeist-runtime/target/wasm32-unknown-unknown/release/deps/zeitgeist_runtime-70466694c71a1cfa.long-type-14257364266321246897.txt'
      = note: the following trait bounds were not satisfied:
              `(frame_system::Pallet<Runtime>, pallet_timestamp::Pallet<Runtime>, pallet_randomness_collective_flip::Pallet<Runtime>, pallet_scheduler::Pallet<Runtime>, pallet_preimage::Pallet<Runtime>, pallet_balances::Pallet<Runtime>, pallet_transaction_payment::Pallet<Runtime>, pallet_treasury::Pallet<Runtime>, pallet_vesting::Pallet<Runtime>, pallet_multisig::Pallet<Runtime>, pallet_bounties::Pallet<Runtime>, pallet_asset_tx_payment::Pallet<Runtime>, pallet_democracy::Pallet<Runtime>, pallet_collective::Pallet<Runtime, Instance1>, pallet_membership::Pallet<Runtime, Instance1>, pallet_collective::Pallet<Runtime, Instance2>, pallet_membership::Pallet<Runtime, Instance2>, pallet_collective::Pallet<Runtime, Instance3>, pallet_membership::Pallet<Runtime, Instance3>, pallet_identity::Pallet<Runtime>, pallet_utility::Pallet<Runtime>, pallet_proxy::Pallet<Runtime>, pallet_contracts::Pallet<Runtime>, orml_currencies::Pallet<Runtime>, orml_tokens::Pallet<Runtime>, zrml_market_commons::Pallet<Runtime>, zrml_authorized::Pallet<Runtime>, zrml_court::Pallet<Runtime>, zrml_liquidity_mining::Pallet<Runtime>, zrml_rikiddo::Pallet<Runtime, Instance1>, zrml_simple_disputes::Pallet<Runtime>, zrml_swaps::Pallet<Runtime>, zrml_prediction_markets::Pallet<Runtime>, zrml_styx::Pallet<Runtime>, cumulus_pallet_parachain_system::Pallet<Runtime>, parachain_info::Pallet<Runtime>, pallet_parachain_staking::Pallet<Runtime>, pallet_author_inherent::Pallet<Runtime>, pallet_author_slot_filter::Pallet<Runtime>, pallet_author_mapping::Pallet<Runtime>, cumulus_pallet_xcm::Pallet<Runtime>, cumulus_pallet_dmp_queue::Pallet<Runtime>, pallet_xcm::Pallet<Runtime>, cumulus_pallet_xcmp_queue::Pallet<Runtime>, orml_asset_registry::Pallet<Runtime>, orml_unknown_tokens::Pallet<Runtime>, orml_xtokens::Pallet<Runtime>): hidden_include::traits::TryState<u64>`
      = note: this error originates in the macro `create_runtime_api` (in Nightly builds, run with -Z macro-backtrace for more info)

  For more information about this error, try `rustc --explain E0599`.
  error: could not compile `zeitgeist-runtime` due to 2 previous errors
</code>
</pre>
</details>
</details>

You can reproduce this error by checking out the [commit 097ef46](https://github.com/zeitgeistpm/zeitgeist/commit/097ef469e0fce781b5586352267472a7cd4794ac) and building the crate `zeitgeist-runtime`: `cargo build --manifest-path=./runtime/zeitgeist/Cargo.toml --features=parachain,try-runtime`. This issue was fixed in the next [commit c0ec18f](https://github.com/zeitgeistpm/zeitgeist/commit/c0ec18fe50588cc62f3ea7a0d9c07d9c421bcdc8). The fix comes from the Nimbus crate, [commit 908bad9](https://github.com/zeitgeistpm/nimbus/commit/908bad91acfd3bf1c161ddd5a5ba251767e9f440).